### PR TITLE
DELETE for Driver Availability Controller (Driver Availability)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -67,14 +67,14 @@ public class DriverAvailabilityController extends ApiController {
         }
 
     @Operation(summary= "Delete Driver Availability")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
     @DeleteMapping("")
     public Object deletemenuitem(
         @Parameter(name="id") @RequestParam Long id) 
         {
         DriverAvailability drivav = driverAvailabilityRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
-    
+        
          driverAvailabilityRepository.delete(drivav);
         return genericMessage("Driver Availability with id %s deleted".formatted(id));
         }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -76,6 +76,6 @@ public class DriverAvailabilityController extends ApiController {
             .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
     
          driverAvailabilityRepository.delete(drivav);
-        return genericMessage("Driver Availabilty with id %s deleted".formatted(id));
+        return genericMessage("Driver Availability with id %s deleted".formatted(id));
         }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -64,5 +64,18 @@ public class DriverAvailabilityController extends ApiController {
         DriverAvailability savedDriverAvailability = driverAvailabilityRepository.save(driverAvailability);
 
         return savedDriverAvailability;
-    }
+        }
+
+    @Operation(summary= "Delete Driver Availability")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deletemenuitem(
+        @Parameter(name="id") @RequestParam Long id) 
+        {
+        DriverAvailability drivav = driverAvailabilityRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+    
+         driverAvailabilityRepository.delete(drivav);
+        return genericMessage("Driver Availabilty with id %s deleted".formatted(id));
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -96,7 +96,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
         }
-        @WithMockUser(roles = { "ADMIN", "USER" })
+        @WithMockUser(roles = { "DRIVER" })
         @Test
         public void admin_can_delete_a_driveravailibilty() throws Exception {
             // arrange
@@ -125,7 +125,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
             assertEquals("Driver Availability with id 1 deleted", json.get("message"));
         }
 
-        @WithMockUser(roles = { "ADMIN", "USER" })
+    @WithMockUser(roles = { "DRIVER" })
     @Test
     public void admin_tries_to_delete_non_existant_driveravailibilty_and_gets_right_error_message()
             throws Exception {

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -96,4 +96,54 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
         }
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_driveravailibilty() throws Exception {
+            // arrange
+    
+            DriverAvailability availability1 = DriverAvailability.builder()
+                                .driverId(1L)
+                                .day("Friday")
+                                .startTime("10:00AM")
+                                .endTime("11:00AM")
+                                .notes("old car")
+                                .build();
+    
+            when(driverAvailabilityRepository.findById(eq(1L))).thenReturn(Optional.of(availability1));
+    
+            // act
+            MvcResult response = mockMvc.perform(
+                    delete("/api/driverAvailability?id=1")
+                            .with(csrf()))
+                    .andExpect(status().isOk()).andReturn();
+    
+            // assert
+            verify(driverAvailabilityRepository, times(1)).findById(1L);
+            verify(driverAvailabilityRepository, times(1)).delete(any());
+    
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Driver Availability with id 1 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_driveravailibilty_and_gets_right_error_message()
+            throws Exception {
+        // arrange
+
+        when(driverAvailabilityRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/driverAvailability?id=1")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(driverAvailabilityRepository, times(1)).findById(1L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("DriverAvailability with id 1 not found", json.get("message"));
+    }
+
+        
 }


### PR DESCRIPTION
adds DELETE endpoint for Driver Availability Controller, enter ID for in ID space to delete availability

working deployment: https://project-notaryaman-dev.dokku-16.cs.ucsb.edu/

<img width="847" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-4/assets/124849392/0d968358-b985-4fdd-afd8-bda0aa4e8e71">


closes #13 