### PR TITLE
Wt driver availability admin get all endpoint and get by id endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -65,4 +65,25 @@ public class DriverAvailabilityController extends ApiController {
 
         return savedDriverAvailability;
     }
+
+    @Operation(summary = "Get a list of all driver availabilities")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public ResponseEntity<String> allDriverAvailabilities()
+            throws JsonProcessingException {
+        Iterable<DriverAvailability> driverAvailabilities = driverAvailabilityRepository.findAll();
+        String body = mapper.writeValueAsString(driverAvailabilities);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary = "Get driver availability by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin")
+    public DriverAvailability driverAvailabilityByID(
+            @Parameter(name = "id", description = "Long, id number of driver availability to get", example = "1", required = true) @RequestParam Long id)
+            throws JsonProcessingException {
+        DriverAvailability driverAvailability = driverAvailabilityRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+        return driverAvailability;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -41,7 +41,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         @MockBean
         UserRepository userRepository;
-        
+
         // Authorization tests for /api/driverAvailability/post
 
         @Test
@@ -95,5 +95,157 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
             String expectedJson = mapper.writeValueAsString(availability1);
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
+        }
+
+        // Authorization tests for /api/driverAvailability/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_get_all_of_theirs() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                                .andExpect(status().is(403)); // logged
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                                .andExpect(status().is(403)); // logged
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin?id=7"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin?id=7"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_can_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/driverAvailability/admin?id=7"))
+                                .andExpect(status().is(404)); // logged, but no id exists
+        }
+        
+        // ADMIN GET BY ID
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void test_that_logged_in_admin_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                DriverAvailability driverAvailability = DriverAvailability.builder()
+                                .driverId(userId)
+                                .day("Monday")
+                                .startTime("10:00AM")
+                                .endTime("12:30PM")
+                                .notes("")
+                                .build();
+
+                when(driverAvailabilityRepository.findById(eq(7L))).thenReturn(Optional.of(driverAvailability));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/driverAvailability/admin?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(driverAvailabilityRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(driverAvailability);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void test_that_logged_in_admin_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(driverAvailabilityRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/driverAvailability/admin?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(driverAvailabilityRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("DriverAvailability with id 7 not found", json.get("message"));
+        }     
+
+
+        // GET ALL
+
+        @WithMockUser(roles = { "ADMIN" , "USER" })
+        @Test
+        public void logged_in_admin_can_get_all_driver_availabilities() throws Exception {
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                DriverAvailability availability1 = DriverAvailability.builder()
+                                .driverId(userId)
+                                .day("Monday")
+                                .startTime("10:30AM")
+                                .endTime("12:30PM")
+                                .notes("")
+                                .build();
+
+                DriverAvailability availability2 = DriverAvailability.builder()
+                                .driverId(userId)
+                                .day("Tuesday")
+                                .startTime("10:30AM")
+                                .endTime("12:30PM")
+                                .notes("")
+                                .build();
+
+
+                ArrayList<DriverAvailability> expectedDriverAvailabilities = new ArrayList<>();
+                expectedDriverAvailabilities.addAll(Arrays.asList(availability1, availability2));
+
+                when(driverAvailabilityRepository.findAll()).thenReturn(expectedDriverAvailabilities);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(driverAvailabilityRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedDriverAvailabilities);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
         }
 }


### PR DESCRIPTION
DriverAvailability admin endpoints

/api/driverAvailability/admin/all endpoint:
- gets all driver availability requests in the repository and returns them only if the request comes from a user with admin access

/api/driverAvailability/admin?id=x endpoint:
- returns the driver availability row that corresponds to the id

https://gauchoride-wesleytruong-dev.dokku-16.cs.ucsb.edu/swagger-ui/index.html#/
closes #14 