### PR TITLE
 GET for Driver Availability Controller (Driver Availability) 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -78,4 +78,26 @@ public class DriverAvailabilityController extends ApiController {
          driverAvailabilityRepository.delete(drivav);
         return genericMessage("Driver Availability with id %s deleted".formatted(id));
         }
+    
+
+    @Operation(summary= "Update Driver Availability")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PutMapping("")
+    public DriverAvailability updatemenuitem(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid DriverAvailability incoming) {
+
+        DriverAvailability drivav = driverAvailabilityRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+
+        drivav.setDriverId(incoming.getDriverId());
+        drivav.setDay(incoming.getDay());
+        drivav.setStartTime(incoming.getStartTime());
+        drivav.setEndTime(incoming.getEndTime());
+        drivav.setNotes(incoming.getNotes());
+
+        driverAvailabilityRepository.save(drivav);
+
+        return drivav;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -43,7 +43,7 @@ public class DriverAvailabilityController extends ApiController {
     ObjectMapper mapper;
 
     @Operation(summary = "Create a new driver availability for the table")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'DRIVER')")
     @PostMapping("/new")
     public DriverAvailability postDriverAvailability(
         @Parameter(name="day") @RequestParam String day,
@@ -67,7 +67,7 @@ public class DriverAvailabilityController extends ApiController {
         }
 
     @Operation(summary= "Delete Driver Availability")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'DRIVER')")
     @DeleteMapping("")
     public Object deletemenuitem(
         @Parameter(name="id") @RequestParam Long id) 
@@ -81,7 +81,7 @@ public class DriverAvailabilityController extends ApiController {
     
 
     @Operation(summary= "Update Driver Availability")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'DRIVER')")
     @PutMapping("")
     public DriverAvailability updatemenuitem(
             @Parameter(name="id") @RequestParam Long id,
@@ -103,7 +103,7 @@ public class DriverAvailabilityController extends ApiController {
 
 
     @Operation(summary= "List all Driver Availability")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'DRIVER','USER')")
     @GetMapping("/all")
     public Iterable<DriverAvailability> allmenuitems() {
         Iterable<DriverAvailability> drivall = driverAvailabilityRepository.findAll();
@@ -112,7 +112,7 @@ public class DriverAvailabilityController extends ApiController {
 
 
     @Operation(summary= "Get Driver Availability")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'DRIVER','USER')")
     @GetMapping("")
     public DriverAvailability getById(
             @Parameter(name="id") @RequestParam Long id) {

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -77,8 +77,7 @@ public class DriverAvailabilityController extends ApiController {
         
          driverAvailabilityRepository.delete(drivav);
         return genericMessage("Driver Availability with id %s deleted".formatted(id));
-        }
-    
+        }    
 
     @Operation(summary= "Update Driver Availability")
     @PreAuthorize("hasAnyRole('ADMIN', 'DRIVER')")
@@ -120,5 +119,28 @@ public class DriverAvailabilityController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException( DriverAvailability.class, id));
 
         return drivav;
+    }
+
+
+    @Operation(summary = "Get a list of all driver availabilities")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public ResponseEntity<String> allDriverAvailabilities()
+            throws JsonProcessingException {
+        Iterable<DriverAvailability> driverAvailabilities = driverAvailabilityRepository.findAll();
+        String body = mapper.writeValueAsString(driverAvailabilities);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary = "Get driver availability by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin")
+    public DriverAvailability driverAvailabilityByID(
+            @Parameter(name = "id", description = "Long, id number of driver availability to get", example = "1", required = true) @RequestParam Long id)
+            throws JsonProcessingException {
+        DriverAvailability driverAvailability = driverAvailabilityRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+        return driverAvailability;
+
     }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -100,4 +100,25 @@ public class DriverAvailabilityController extends ApiController {
 
         return drivav;
     }
+
+
+    @Operation(summary= "List all Driver Availability")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @GetMapping("/all")
+    public Iterable<DriverAvailability> allmenuitems() {
+        Iterable<DriverAvailability> drivall = driverAvailabilityRepository.findAll();
+        return drivall;
+    }
+
+
+    @Operation(summary= "Get Driver Availability")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @GetMapping("")
+    public DriverAvailability getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        DriverAvailability drivav = driverAvailabilityRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException( DriverAvailability.class, id));
+
+        return drivav;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -98,7 +98,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
         }
-        @WithMockUser(roles = { "DRIVER" })
+        @WithMockUser(roles = { "ADMIN" })
         @Test
         public void admin_can_delete_a_driveravailibilty() throws Exception {
             // arrange
@@ -127,7 +127,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
             assertEquals("Driver Availability with id 1 deleted", json.get("message"));
         }
 
-    @WithMockUser(roles = { "DRIVER" })
+    @WithMockUser(roles = { "ADMIN" })
     @Test
     public void admin_tries_to_delete_non_existant_driveravailibilty_and_gets_right_error_message()
             throws Exception {
@@ -147,7 +147,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         assertEquals("DriverAvailability with id 1 not found", json.get("message"));
     }
 
-    @WithMockUser(roles = { "DRIVER" })
+    @WithMockUser(roles = { "ADMIN"})
     @Test
 public void admin_can_edit_an_existing_driveravailibility() throws Exception {
     // Arrange
@@ -199,7 +199,7 @@ public void admin_can_edit_an_existing_driveravailibility() throws Exception {
 
 
 
-    @WithMockUser(roles = { "DRIVER" })
+    @WithMockUser(roles = { "ADMIN" })
     @Test
     public void admin_cannot_edit_ucsbdiningcommonsmenuitem_that_does_not_exist() throws Exception {
         // arrange
@@ -237,14 +237,14 @@ public void admin_can_edit_an_existing_driveravailibility() throws Exception {
                 .andExpect(status().is(403)); // logged out users can't get all
     }
 
-    @WithMockUser(roles = { "USER","DRIVER" })
+    @WithMockUser(roles = { "USER"})
     @Test
     public void logged_in_users_can_get_all() throws Exception {
         mockMvc.perform(get("/api/driverAvailability/all"))
                 .andExpect(status().is(200)); // logged
     }
 
-    @WithMockUser(roles = { "USER","DRIVER" })
+    @WithMockUser(roles = { "USER"})
     @Test
     public void logged_in_user_can_get_all_driveravailibilty() throws Exception {
         DriverAvailability item1 = DriverAvailability.builder()
@@ -284,7 +284,7 @@ public void admin_can_edit_an_existing_driveravailibility() throws Exception {
                 .andExpect(status().is(403)); // logged out users can't get by id
     }
 
-    @WithMockUser(roles = { "DRIVER" })
+    @WithMockUser(roles = { "USER" })
     @Test
     public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
 
@@ -311,7 +311,7 @@ public void admin_can_edit_an_existing_driveravailibility() throws Exception {
         assertEquals(expectedJson, responseString);
     }
 
-    @WithMockUser(roles = { "DRIVER" })
+    @WithMockUser(roles = { "USER" })
     @Test
     public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
 


### PR DESCRIPTION
adds GET endpoint for Driver Availability Controller, enter ID for in ID space to delete availability

working deployment: https://project-notaryaman-dev.dokku-16.cs.ucsb.edu/

<img width="846" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-4/assets/124849392/313910ec-7ec8-4fbc-9fa1-1364e067a6e0">

<img width="849" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-4/assets/124849392/95e245ca-52c4-449e-a920-21e4b7cf8ff4">


closes #11 