### PR TITLE
FEATURE: All users should not be able to see "Apply to be a Rider" if they are a rider

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_MEMBER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -13,7 +13,7 @@ export default function UsersTable({ users}) {
             }
         }
     }
-
+ 
     // Stryker disable all : hard to test for query caching
     const toggleRiderMutation = useBackendMutation(
         cellToAxiosParamsToggleRider,

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -674,8 +674,29 @@ describe("AppNavbar tests", () => {
         
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
         const applyMenu = screen.queryByText("Apply to be a Rider");
-        expect(applyMenu).not.toBeInTheDocument();      
+        expect(applyMenu).toBeInTheDocument();      
     });
+
+    test("Rider page link should appear for a user that is a rider", async() => {
+        const currentUser = currentUserFixtures.riderOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const driverLink = screen.queryByTestId("appnavbar-driver-link");
+        expect(driverLink).not.toBeInTheDocument();      
+        
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const applyMenu = screen.queryByText("Apply to be a Rider");
+        expect(applyMenu).not.toBeInTheDocument();      
+    }); 
 
 });
 


### PR DESCRIPTION
Closes issue #7 

"Apply to be a Rider" button when user is not rider: 
<img width="1728" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-4/assets/92065327/fbeb5c2a-7485-45d4-9788-5e20e79000cc">

"Apply to be a Rider" button disappears when user is a rider:
<img width="1728" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-4/assets/92065327/86f76c19-8ba3-4c21-ba77-9da3850399c2">
