### PR TITLE
fixed chat display

### DIFF
--- a/frontend/src/main/components/ChatMessage/ChatDisplay.js
+++ b/frontend/src/main/components/ChatMessage/ChatDisplay.js
@@ -43,7 +43,7 @@ const ChatDisplay = () => {
   return (
     <div>
       <Stack>
-        {[...page.content].reverse().map((message) => (
+        {[...page.content].reverse().map((message) => ( // removed a .reverse() in the middle
           <ChatMessageDisplay key={message.chatMessage.id} chatMessage={message} />
         ))}
       </Stack>

--- a/frontend/src/main/components/ChatMessage/ChatMessageDisplay.js
+++ b/frontend/src/main/components/ChatMessage/ChatMessageDisplay.js
@@ -11,11 +11,11 @@ function ChatMessageDisplay({ chatMessage }) {
   return (
     <Card data-testid="ChatMessageDisplay">
       <Card.Body>
-        <Card.Title>{chatMessage.chatMessage.payload}</Card.Title>
-        <Card.Subtitle className="mb-2 text-muted">{formatTimestamp(chatMessage.chatMessage.timestamp)}</Card.Subtitle>
         <Card.Text>
           Email: {chatMessage.email}
         </Card.Text>
+        <Card.Subtitle className="mb-2 text-muted">{formatTimestamp(chatMessage.chatMessage.timestamp)}</Card.Subtitle>
+        <Card.Title>{chatMessage.chatMessage.payload}</Card.Title>
       </Card.Body>
     </Card>
   );


### PR DESCRIPTION
Closes issue #4 

chat now properly displays in order from top to bottom:
email,
date,
message

<img width="1341" alt="image" src="https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-4/assets/92065327/431fd935-78a9-474c-82ba-fe656e95686b">
